### PR TITLE
Cleaning reload and improvating its performance

### DIFF
--- a/[gameplay]/reload/reload_c.lua
+++ b/[gameplay]/reload/reload_c.lua
@@ -1,38 +1,38 @@
-﻿local blockedTasks = 
+local blockedTasks = 
 {
-	"TASK_SIMPLE_IN_AIR", -- We're falling or in a jump.
-	"TASK_SIMPLE_JUMP", -- We're beginning a jump
-	"TASK_SIMPLE_LAND", -- We're landing from a jump
-	"TASK_SIMPLE_GO_TO_POINT", -- In MTA, this is the player probably walking to a car to enter it
-	"TASK_SIMPLE_NAMED_ANIM", -- We're performing a setPedAnimation
-	"TASK_SIMPLE_CAR_OPEN_DOOR_FROM_OUTSIDE", -- Opening a car door
-	"TASK_SIMPLE_CAR_GET_IN", -- Entering a car
-	"TASK_SIMPLE_CLIMB", -- We're climbing or holding on to something
-	"TASK_SIMPLE_SWIM",
-	"TASK_SIMPLE_HIT_HEAD", -- When we try to jump but something hits us on the head
-	"TASK_SIMPLE_FALL", -- We fell
-	"TASK_SIMPLE_GET_UP" -- We're getting up from a fall
+	["TASK_SIMPLE_IN_AIR"] = true, -- We're falling or in a jump.
+	["TASK_SIMPLE_JUMP"] = true, -- We're beginning a jump
+	["TASK_SIMPLE_LAND"] = true, -- We're landing from a jump
+	["TASK_SIMPLE_GO_TO_POINT"] = true, -- In MTA, this is the player probably walking to a car to enter it
+	["TASK_SIMPLE_NAMED_ANIM"] = true, -- We're performing a setPedAnimation
+	["TASK_SIMPLE_CAR_OPEN_DOOR_FROM_OUTSIDE"] = true, -- Opening a car door
+	["TASK_SIMPLE_CAR_GET_IN"] = true, -- Entering a car
+	["TASK_SIMPLE_CLIMB"] = true, -- We're climbing or holding on to something
+	["TASK_SIMPLE_SWIM"] = true,
+	["TASK_SIMPLE_HIT_HEAD"] = true, -- When we try to jump but something hits us on the head
+	["TASK_SIMPLE_FALL"] = true, -- We fell
+	["TASK_SIMPLE_GET_UP"] = true -- We're getting up from a fall
 }
 
 local function reloadWeapon()
-	-- Usually, getting the simplest task is enough to suffice
-	local task = getPedSimplestTask (localPlayer) 
 
-	-- Iterate through our list of blocked tasks
-	for idx, badTask in ipairs(blockedTasks) do
-		-- If the player is performing any unwanted tasks, do not fire an event to reload
-		if (task == badTask) then
-			return
-		end
-	end
+	local task = getPedSimplestTask (localPlayer) -- Usually, getting the simplest task is enough to suffice
+	local slot = getPedWeaponSlot(localPlayer)
 	
-	triggerServerEvent("relWep", resourceRoot)
+	if blockedTasks[task] then return end --If the player is performing any unwanted tasks, do not fire an event to reload
+	if slot < 2 or slot > 5 then return end --If the player does not have a reloadable gun, do not fire an event to reload
+	
+	triggerLatentServerEvent("relWep",4000,false,resourceRoot) --Its really small event so use latent event instead to reduce traffic and CPU usage
+	
 end
 
 -- The jump task is not instantly detectable and bindKey works quicker than getControlState
 -- If you try to reload and jump at the same time, you will be able to instant reload.
 -- We work around this by adding an unnoticable delay to foil this exploit.
-addCommandHandler("Reload weapon", function()
-	setTimer(reloadWeapon, 50, 1)
-end)
-bindKey("r", "down", "Reload weapon")
+
+local function reload()
+	setTimer(reloadWeapon,50,1)
+end
+
+addCommandHandler("reload",reload,false)
+bindKey("r","down","reload")


### PR DESCRIPTION
Reload script has had an exploit which made it possible to cause lot of lag if server does not have any kind of command-spam protection. I have seen unprotected and weak performancing servers even freezing/crashing by this. The problem is that reload script does not limit in any way the usage of reload command so anytime when it is used, it sends sometimes even innecessary reload events to server. This PR includes some checks and performance improvations. Also some script cleaning has been done on this PR

Also if we wanted to add performance more, we could check if player actually has proper amount of bullets to "realistically" reload their weapon and also make events player-based. But even these little changes help a lot.

As mentioned, this PR also has some basic script cleaning like making the taskes as table keys instead of table values and by this removing need of for loop. Also made the addCommandHandler and bindKey section a bit cleaner and changed command from "Reload weapon" to "reload" to make it more player-friendly.